### PR TITLE
does not remove <transition> element if onLeave handler provided

### DIFF
--- a/packages/react-vue-helper/build.js
+++ b/packages/react-vue-helper/build.js
@@ -3596,7 +3596,7 @@ function leave (ref) {
     });
   }
   onLeave && onLeave(el, _cb);
-  if (!expectsCSS && !userWantsControl) {
+  if (!expectsCSS && !userWantsControl && !onLeave) {
     _cb();
   }
 }


### PR DESCRIPTION
So the real correct way to do this seems to be to fix this function `getHookArgumentsLength`, however it seems that it has a hard time analyzing the number of arguments in the vue-to-react transpilation scheme setup here. 

I could be wrong, so consider this just an indicator of what needs to be fixed. 

Essentially, my fix is a weaker assumption:
- *if there is an `onLeave` handler, it means do not remove the element.* 

However, in a real Vue app, you likely can use such handlers for other things without manually removing the element, which is why `getHookArgumentsLength` exists to smooth things over. My guess is those situations are just edge cases. 90% of the time if you are going to provide such a handler you will finish the job and call `done` yourself. 

Hopefully this can get merged sooner than later, as I'd like to present your repo (since you're the original creator) rather than a fork.
